### PR TITLE
Implement std::error::Error for JsonError

### DIFF
--- a/src/json_error.rs
+++ b/src/json_error.rs
@@ -42,3 +42,5 @@ impl Display for JsonError {
         }
     }
 }
+
+impl std::error::Error for JsonError {}


### PR DESCRIPTION
For interoperability.